### PR TITLE
Fix Admin Logout

### DIFF
--- a/AdminFront/angular.json
+++ b/AdminFront/angular.json
@@ -72,7 +72,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "AdminFront:build"
+            "browserTarget": "AdminFront:build",
+            "port":4200
           },
           "configurations": {
             "production": {

--- a/AdminFront/src/app/app.component.ts
+++ b/AdminFront/src/app/app.component.ts
@@ -3,6 +3,8 @@ import { ViewChild } from '@angular/core';
 import { Component } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { HttpClient } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -13,62 +15,53 @@ export class AppComponent {
   @ViewChild(MatSidenav)
   sidenav!: MatSidenav;
 
-  constructor(private observer: BreakpointObserver) { }
+  constructor(private observer: BreakpointObserver,
+    private http: HttpClient
+  ) { }
 
   ngAfterViewInit() {
-  //gets cookie from browser and uses it to access user details
-    let userCookie = getCookie("user");
-    
-    if (!userCookie || JSON.parse(JSON.parse(userCookie)).userType != "Admin") {
-      // window.location.href = "https://mytechie.pro";
-    } else {
-      
-      
-      let json = JSON.parse(userCookie);
-      let user = JSON.parse(json);
-      
-      let firstName = user.firstName;
-      let lastName = user.lastName;
-      let fullName = firstName + " " + lastName;
-      
-      // Assigns name displayed on the admin page to the name based on the user cookie.
-      document.getElementById("fullName")!.innerHTML = fullName;
-
-      this.observer.observe(['(max-width: 800px)']).subscribe((res) => {
-        if (res.matches) {
-          this.sidenav.mode = 'over';
-          this.sidenav.close();
-        } else {
-          this.sidenav.mode = 'side';
-          this.sidenav.open();
+    this.http.get<any>(`${environment.apiEndpoint}/auth/checkSession`, { withCredentials: true })
+      .subscribe({
+        next: (user) => {
+          if (user.userType !== 'Admin') {
+            console.log(user);
+            window.location.href = environment.clientUrl;
+            return;
+          }
+          document.getElementById("fullName")!.innerHTML = 
+            `${user.firstName} ${user.lastName}`;
+  
+          this.observer.observe(['(max-width: 800px)']).subscribe((res) => {
+            if (res.matches) {
+              this.sidenav.mode = 'over';
+              this.sidenav.close();
+            } else {
+              this.sidenav.mode = 'side';
+              this.sidenav.open();
+            }
+          });
+        },
+        error: () => {
+          console.log("error");
+          window.location.href = environment.clientUrl;
         }
       });
-    }
   }
 
   public signOut() {
-    localStorage.removeItem('user');
-    document.cookie = "user=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.mytechie.pro;";
-    window.location.reload();
+    this.http.post(`${environment.apiEndpoint}/auth/logout`, {}, { 
+      withCredentials: true,
+      observe: 'response'
+    }).subscribe({
+      next: (response) => {
+        console.log('Logout successful');
+        window.location.href = environment.clientUrl;
+      },
+      error: (error) => {
+        console.error('Logout failed:', error);
+        window.location.href = environment.clientUrl;
+      }
+    });
   }
 }
 
-/**
- * Gets the cookie by the cookie name and formats it as a cookie string.
- * @param cname 
- * @returns 
- */
-function getCookie(cname: string) {
-  let name = cname + "=";
-  let ca = document.cookie.split(';');
-  for(let i = 0; i < ca.length; i++) {
-    let c = ca[i];
-    while (c.charAt(0) == ' ') {
-      c = c.substring(1);
-    }
-    if (c.indexOf(name) == 0) {
-      return c.substring(name.length, c.length);
-    }
-  }
-  return "";
-}

--- a/AdminFront/src/environments/environment.prod.ts
+++ b/AdminFront/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiEndpoint: 'https://mytechie.pro/api'
+  apiEndpoint: 'https://mytechie.pro/api',
+  clientUrl: 'https://mytechie.pro'
 };

--- a/AdminFront/src/environments/environment.prod.ts
+++ b/AdminFront/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
   apiEndpoint: 'https://mytechie.pro/api',
-  clientUrl: 'https://mytechie.pro'
+  clientUrl: 'https://mytechie.pro',
+  adminUrl: 'https://mytechie.pro/admin'
 };

--- a/AdminFront/src/environments/environment.ts
+++ b/AdminFront/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  apiEndpoint: 'http://localhost:3333/api' //'https://mytechie.pro/api'
+  apiEndpoint: 'http://localhost:3333/api', //'https://mytechie.pro/api'
+  clientUrl: 'http://localhost:8080' //'https://mytechie.pro'
 };
 
 /*

--- a/AdminFront/src/environments/environment.ts
+++ b/AdminFront/src/environments/environment.ts
@@ -5,7 +5,8 @@
 export const environment = {
   production: false,
   apiEndpoint: 'http://localhost:3333/api', //'https://mytechie.pro/api'
-  clientUrl: 'http://localhost:8080' //'https://mytechie.pro'
+  clientUrl: 'http://localhost:8080', //'https://mytechie.pro'
+  adminUrl: 'http://localhost:4200'
 };
 
 /*

--- a/Backend/src/app.ts
+++ b/Backend/src/app.ts
@@ -30,7 +30,7 @@ class App {
     }
 
     private initializeMiddlewares() {
-        const allowedOrigins = ['https://mytechie.pro', 'https://mytechie.pro/api/*', 'http://localhost:80','http://localhost:4200'];
+        const allowedOrigins = ['https://mytechie.pro', 'https://mytechie.pro/api/*', 'http://localhost:80','http://localhost:4200',"http://localhost:8080"];
         this.app.use(bodyParser.json());
         this.app.use(cookieParser());
 

--- a/Backend/src/controllers/authentication/authentication.controller.ts
+++ b/Backend/src/controllers/authentication/authentication.controller.ts
@@ -170,11 +170,18 @@ class AuthenticationController implements Controller {
     // Logs the User out
     // Sets the HttpOnly cookie to an expired state
     private loggingOut = (request: Request, response: Response) => {
+        try {
+            // Clear the Authorization cookie
+            response.setHeader('Set-Cookie', [
+                'Authorization=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=None',
+                'user=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=None'
+            ]);
 
-        // Clear the cookie with matching attributes, except Max-Age which is set to expire the cookie
-        response.setHeader('Set-Cookie', 'Authorization=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=None');
-
-        response.send(200);
+            response.sendStatus(200);
+        } catch (error) {
+            console.error('Logout error:', error);
+            response.sendStatus(500);
+        }
     };
 
     // Registers a new User

--- a/ClientFront/angular.json
+++ b/ClientFront/angular.json
@@ -74,7 +74,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "computer-guy-frontend:build"
+            "browserTarget": "computer-guy-frontend:build",
+            "port": 8080
           },
           "configurations": {
             "production": {

--- a/ClientFront/src/app/app.component.ts
+++ b/ClientFront/src/app/app.component.ts
@@ -67,9 +67,8 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     this.authService.user.subscribe((user) => {
-      
-      if (user){
-        this.isProfessional = user.userType === 'Professional' ?? false;
+      if (user) {
+        this.isProfessional = (user.userType === 'Professional');
         this.updateUIBasedOnUser(user);
       } else {
         this.isProfessional = false;

--- a/ClientFront/src/app/modules/sign-in/sign-in.component.ts
+++ b/ClientFront/src/app/modules/sign-in/sign-in.component.ts
@@ -11,6 +11,7 @@ import { AuthService } from "src/app/shared/services/auth.service";
 import { first, map } from "rxjs/operators";
 import { plainToClass } from "class-transformer";
 import { Router } from "@angular/router";
+import { environment } from "src/environments/environment";
 
 @Component({
   selector: "app-sign-in",
@@ -103,7 +104,7 @@ export class SignInComponent implements OnInit {
           this.router.navigateByUrl('/').then(() => {
           })
         } else {
-          window.location.href = 'https://mytechie.pro/admin';
+          window.location.href = environment.adminUrl;
         }
       },
       (error) => {

--- a/ClientFront/src/environments/environment.prod.ts
+++ b/ClientFront/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: true,
-  apiEndpoint: 'https://mytechie.pro/api'
+  apiEndpoint: 'https://mytechie.pro/api',
+  clientUrl: 'https://mytechie.pro',
+  adminUrl: 'https://mytechie.pro/admin'
 };

--- a/ClientFront/src/environments/environment.ts
+++ b/ClientFront/src/environments/environment.ts
@@ -4,7 +4,9 @@
 
 export const environment = {
   production: false,
-  apiEndpoint: 'http://localhost:3333/api' // 'https://mytechie.pro/api'//'http://backenduploadfiles-env.eba-fbpxbdmr.us-west-2.elasticbeanstalk.com'
+  apiEndpoint: 'http://localhost:3333/api', // 'https://mytechie.pro/api'//'http://backenduploadfiles-env.eba-fbpxbdmr.us-west-2.elasticbeanstalk.com'
+  clientUrl: 'http://localhost:8080',
+  adminUrl: 'http://localhost:4200'
 };
 
 /*


### PR DESCRIPTION
### 1. Issue
The old admin logout was not working because:
1. It simply reloads the page
2. `getCookie` function is not working (cookie is set to be httpOnly but the function is trying to get it from DOM). And even though the cookie validation doesn't work at all, in `app.component.ts`, there was no redirection or reload, which I suspect is also the reason why a client can switch to the admin page @JoanneH2050 

### 2. Fix
To make the login validation & logout work, I did:
1. Instead of grabbing cookies from the DOM, check the admin login status with the existing `checkSession` endpoint. If there's no valid session, redirect to the client app
4. By clicking logout, trigger the controller function cookie and redirect to the client app.

### 3. Other Changes
Also made some config changes to let admin and client run together locally to see whether the redirection works correctly.

Now running `ng serve`, client is running at port 8080 and admin at port 4200 by default.

### 4. Steps to test
To see the changes working, you need to:
1. git pull
2. git checkout fix_logout
5. run BackEnd & ClientFront & AdminFront together. 
6. Go to `http://localhost:4200` (admin) , it should redirect you to `http://localhost:8080` (client) as you're not logged in 
7. Log in from `http://localhost:8080` with an admin account 

> username: john1@my.bcit.ca
> password: John1@my.bcit.ca

8. it should redirect you to `http://localhost:4200` (admin) as the user type is admin
9. Click `Logout`
10.  it should redirect you to `http://localhost:8080` (client)