### PR TITLE
Fix Bug: (C-03) Hide redundant buttons in forgot password view

### DIFF
--- a/ClientFront/src/app/modules/sign-in/sign-in.component.html
+++ b/ClientFront/src/app/modules/sign-in/sign-in.component.html
@@ -49,15 +49,18 @@
 </mat-dialog-content>
 
 <mat-dialog-actions class="d-flex flex-column justify-content-end">
-  <button mat-button color="accent" (click)="toggleSignInForgotPw()">
+  <!-- <button mat-button color="accent" (click)="toggleSignInForgotPw()"> -->
+  <!-- Fix From Niko: isResetPw === false, “Create a new account” button will show up. By default, after clicking the "Forgot password" button, isResetPw === ture -->
+  <button mat-button color="accent" (click)="toggleSignInForgotPw()" *ngIf="!isResetPw">
     {{
       isResetPw
         ? ("Dictionary.SignIn" | translate)
         : ("Dictionary.ForgotPassword" | translate)
     }}
   </button>
-
-  <button mat-button color="accent" (click)="createAccount()">
+  <!-- <button mat-button color="accent" (click)="createAccount()"> -->
+  <!-- Fix from Niko: isResetPw === false, “Create a new account” button will show up. By default, after clicking the "Forgot password" button, isResetPw === ture -->
+  <button mat-button color="accent" (click)="createAccount()" *ngIf="!isResetPw">
     {{ "Dictionary.CreateAccount" | translate }}
   </button>
 

--- a/ClientFront/src/app/modules/sign-in/sign-in.component.html
+++ b/ClientFront/src/app/modules/sign-in/sign-in.component.html
@@ -50,7 +50,7 @@
 
 <mat-dialog-actions class="d-flex flex-column justify-content-end">
   <!-- <button mat-button color="accent" (click)="toggleSignInForgotPw()"> -->
-  <!-- Fix From Niko: isResetPw === false, “Create a new account” button will show up. By default, after clicking the "Forgot password" button, isResetPw === ture -->
+  <!-- Fix From Niko: isResetPw === false, “Sign in” button will not show up. By default, after clicking the "Forgot password" button, isResetPw === ture, button will show up-->
   <button mat-button color="accent" (click)="toggleSignInForgotPw()" *ngIf="!isResetPw">
     {{
       isResetPw
@@ -59,7 +59,7 @@
     }}
   </button>
   <!-- <button mat-button color="accent" (click)="createAccount()"> -->
-  <!-- Fix from Niko: isResetPw === false, “Create a new account” button will show up. By default, after clicking the "Forgot password" button, isResetPw === ture -->
+  <!-- Fix from Niko: isResetPw === false, “Create a new account” button will not show up. By default, after clicking the "Forgot password" button, isResetPw === ture, button will show up -->
   <button mat-button color="accent" (click)="createAccount()" *ngIf="!isResetPw">
     {{ "Dictionary.CreateAccount" | translate }}
   </button>

--- a/ClientFront/src/app/modules/sign-in/sign-in.component.html
+++ b/ClientFront/src/app/modules/sign-in/sign-in.component.html
@@ -49,8 +49,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions class="d-flex flex-column justify-content-end">
-  <!-- <button mat-button color="accent" (click)="toggleSignInForgotPw()"> -->
-  <!-- Fix From Niko: isResetPw === false, “Sign in” button will not show up. By default, after clicking the "Forgot password" button, isResetPw === ture, button will show up-->
   <button mat-button color="accent" (click)="toggleSignInForgotPw()" *ngIf="!isResetPw">
     {{
       isResetPw
@@ -58,8 +56,6 @@
         : ("Dictionary.ForgotPassword" | translate)
     }}
   </button>
-  <!-- <button mat-button color="accent" (click)="createAccount()"> -->
-  <!-- Fix from Niko: isResetPw === false, “Create a new account” button will not show up. By default, after clicking the "Forgot password" button, isResetPw === ture, button will show up -->
   <button mat-button color="accent" (click)="createAccount()" *ngIf="!isResetPw">
     {{ "Dictionary.CreateAccount" | translate }}
   </button>

--- a/ClientFront/src/app/modules/sign-in/sign-in.component.html
+++ b/ClientFront/src/app/modules/sign-in/sign-in.component.html
@@ -1,5 +1,5 @@
 <!-- <div class="container-fluid"> -->
-<h2 mat-dialog-title>{{ "Dictionary.SignIn" | translate }}</h2>
+<h2 mat-dialog-title>{{ isResetPw ? ("Dictionary.ForgotPassword" | translate) : ("Dictionary.SignIn" | translate) }}</h2>
 
 <mat-dialog-content [formGroup]="formGroup" class="row">
   <mat-form-field class="w-100">


### PR DESCRIPTION

**Description:**
After clicking the "Forgot password" button, remove the "Sign in" and "Create account" buttons from the view to maintain a cleaner user flow for password reset.

**Changes:**
- When users navigate to forgot password view, remove the "Sign in" and "Create account" buttons
- Simplify the password reset flow by showing only relevant actions (Cancel/Send Email)

**Screenshots:**
**Before:**
<img width="180" alt="image" src="https://github.com/user-attachments/assets/ab2c500b-2b42-464b-9b2d-ad10ec9de2ca" />
**After:**
<img width="180" alt="image" src="https://github.com/user-attachments/assets/687a10e1-9118-4fda-8132-91c0605a9f1f" />
