### PR TITLE
Implement pro payment setup UI

### DIFF
--- a/ClientFront/src/app/modules/settings/settings.component.html
+++ b/ClientFront/src/app/modules/settings/settings.component.html
@@ -65,7 +65,7 @@
       </div>
   
       <div *ngIf="stripeConnected" class="stripe-status">
-        <div class="status-info">
+        <div>
           <span class="success-icon">✓</span>
           <p class="status-text">Stripe Account Connected</p>
           <p class="account-id">Account ID: {{stripeAccountId}}</p>

--- a/ClientFront/src/app/modules/settings/settings.component.html
+++ b/ClientFront/src/app/modules/settings/settings.component.html
@@ -65,9 +65,14 @@
       </div>
   
       <div *ngIf="stripeConnected" class="stripe-status">
-        <span class="success-icon">✓</span>
-        <p class="status-text">Stripe Account Connected</p>
-        <p class="account-id">Account ID: {{stripeAccountId}}</p>
+        <div class="status-info">
+          <span class="success-icon">✓</span>
+          <p class="status-text">Stripe Account Connected</p>
+          <p class="account-id">Account ID: {{stripeAccountId}}</p>
+        </div>
+        <button class="stripe-button">
+          <strong>Manage Stripe Connection</strong>
+        </button>
       </div>
     </div>
   </div>

--- a/ClientFront/src/app/modules/settings/settings.component.html
+++ b/ClientFront/src/app/modules/settings/settings.component.html
@@ -1,14 +1,11 @@
 <div class="form-container">
-  <h1 class="form-title text-center">
-    <strong>{{ editing ? 'Edit Your Profile' : 'Your Profile' }}</strong>
-  </h1>
-
   <div *ngIf="successMessage" class="success-message text-center">
     {{ successMessage }}
   </div>
 
-  <br><br>
-  <form [formGroup]="settingsForm" (ngSubmit)="submitForm()">
+  <!-- Personal Infomation Card -->
+  <form [formGroup]="settingsForm" (ngSubmit)="submitForm()" class="settings-card">
+    <h2 class="section-title"><strong>Personal Information</strong></h2>
     <div class="row">
       <div class="column">
         <label for="firstName"><strong>First Name</strong></label>
@@ -52,5 +49,28 @@
       <button type="submit" [disabled]="formDisabled" *ngIf="editing"><strong>Save</strong></button>
     </div>
   </form>
+
+  <div class="section-divider"></div>
+
+  <!-- Stripe Connection Section -->
+  <div *ngIf="isProfessional" class="stripe-section">
+    <h2 class="section-title"><strong>Payment Setup</strong></h2>
+
+    <div class="stripe-content">
+      <div *ngIf="!stripeConnected" class="stripe-connect">
+        <p class="stripe-description">Connect your Stripe account to receive payments from clients.</p>
+        <button class="stripe-button" (click)="connectStripe()">
+          <strong>Connect with Stripe</strong>
+        </button>
+      </div>
+  
+      <div *ngIf="stripeConnected" class="stripe-status">
+        <span class="success-icon">✓</span>
+        <p class="status-text">Stripe Account Connected</p>
+        <p class="account-id">Account ID: {{stripeAccountId}}</p>
+      </div>
+    </div>
+  </div>
+
   <br><br><br><br>
 </div>

--- a/ClientFront/src/app/modules/settings/settings.component.scss
+++ b/ClientFront/src/app/modules/settings/settings.component.scss
@@ -148,6 +148,14 @@ form {
 .stripe-status {
   text-align: center;
   padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+
+  .status-info {
+    text-align: center;
+  }
   
   .success-icon {
     color: #28a745;

--- a/ClientFront/src/app/modules/settings/settings.component.scss
+++ b/ClientFront/src/app/modules/settings/settings.component.scss
@@ -1,7 +1,5 @@
 @use "../../../assets/scss/computotal-theme.scss" as theme;
 
-
-
 .row {
   display: flex;
   flex-wrap: wrap;
@@ -14,15 +12,17 @@
   max-width: 50%;
 }
 
-.bg-primary-lighter {
-  background-color: map-get(theme.$computotal-app-primary, "lighter");
-}
-
 .form-container {
   max-width: 70%;
   margin: 0 auto;
   padding: 20px;
   overflow: hidden;
+}
+
+label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 20px ;
 }
 
 input[type="text"],
@@ -54,7 +54,6 @@ button:hover {
   color: rgb(0, 0, 0);
 }
 
-
 .cancel-button {
   background-color: transparent; 
   color: #767676; 
@@ -72,25 +71,101 @@ button:hover {
   color: #ffffff; 
 }
 
-
-
-.h1{
-  font-size: 20px;
-  margin-bottom: 15px;
-  font-size: large;
-  text-align: left;
-  justify-content: left;
+.success-message {
+  color: green;
+  font-size: 16px;
+  font-weight: bold;
+  margin-top: 10px;
 }
 
-label {
-  display: block;
-  margin-bottom: 5px;
-  font-size: 20px ;
+.settings-card {
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  padding: 25px;
+  margin-top: 40px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
-.form-title {
-  font-size: 30px;
-  margin-bottom: 15px;
+form {
+  @extend .settings-card;
+}
+
+.stripe-section {
+  @extend .settings-card;
+}
+
+.section-divider {
+  margin: 40px 0;
+  border-top: 1px solid #eee;
+}
+
+// Stripe section styles
+.stripe-section {
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  padding: 25px;
+  margin-top: 30px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.section-title {
+  font-size: 24px;
+  color: #333;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.stripe-content {
+  max-width: 500px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.stripe-description {
+  color: #666;
+  font-size: 16px;
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.stripe-button {
+  background-color: #174e89;
+  color: white;
+  padding: 10px 25px;
+  border-radius: 25px;
+  font-size: 14px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  
+  &:hover {
+    background-color: #89c0f8;
+    color: rgb(0, 0, 0);
+  }
+}
+
+.stripe-status {
+  text-align: center;
+  padding: 20px;
+  
+  .success-icon {
+    color: #28a745;
+    font-size: 24px;
+    margin-right: 5px;
+  }
+  
+  .status-text {
+    color: #28a745;
+    font-weight: bold;
+    margin: 10px 0;
+    font-size: 16px;
+  }
+  
+  .account-id {
+    color: #666;
+    font-size: 14px;
+  }
 }
 
 @media (max-width: 768px) {
@@ -98,11 +173,4 @@ label {
     flex: 100%;
     max-width: 100%;
   }
-}
-
-.success-message {
-  color: green;
-  font-size: 16px;
-  font-weight: bold;
-  margin-top: 10px;
 }

--- a/ClientFront/src/app/modules/settings/settings.component.scss
+++ b/ClientFront/src/app/modules/settings/settings.component.scss
@@ -153,10 +153,6 @@ form {
   align-items: center;
   gap: 20px;
 
-  .status-info {
-    text-align: center;
-  }
-  
   .success-icon {
     color: #28a745;
     font-size: 24px;

--- a/ClientFront/src/app/modules/settings/settings.component.ts
+++ b/ClientFront/src/app/modules/settings/settings.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from 'src/app/shared/services/auth.service';
 import { User } from 'src/app/shared/models/user';
 import { HttpClient } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-settings',
@@ -19,6 +20,9 @@ export class SettingsComponent implements OnInit {
   private messages: any = {};
   private originalUserData: User | null = null;
   private editSnapshot: any = null;
+  public stripeConnected: boolean = false;
+  public stripeAccountId: string = '';
+  public isProfessional: boolean = false;
 
   constructor(
     private fb: FormBuilder,
@@ -46,6 +50,9 @@ export class SettingsComponent implements OnInit {
       if (user) {
         this.originalUserData = user;
         this.userId = user._id;
+        this.isProfessional = user.userType === 'Professional';
+        this.stripeConnected = !!user.stripeAccountId;
+        this.stripeAccountId = user.stripeAccountId || '';
         this.populateForm(user);
       }
     });
@@ -87,6 +94,14 @@ export class SettingsComponent implements OnInit {
     });
 
     this.changeDetectorRef.detectChanges();
+  }
+
+  connectStripe(): void {
+    if(!this.originalUserData) {
+      this.errorMessage = 'Please sign in first';
+      return;
+    }
+    window.location.href = `${environment.apiEndpoint}/stripe/connect`
   }
 
   submitForm(): void {

--- a/ClientFront/src/assets/i18n/en-us.json
+++ b/ClientFront/src/assets/i18n/en-us.json
@@ -177,7 +177,7 @@
     "ReviewRequired": "Please provide a rating and comment.",
     "ReviewSubmitSuccess": "Your review has been submitted successfully!",
     "ReviewSubmitFailure": "Failed to submit your review. Please try again.",
-    "ProfileSaveSuccess": "Your profile has been updated successfully!",
+    "ProfileSaveSuccess": "Your peronal infomation has been updated successfully!",
     "ProfileSaveError": "Failed to save profile info. Please try again.",
     "FormInvalid": "Please fill out all required fields.",
     "additionalComments": "Additional Comments",


### PR DESCRIPTION
## Changes made
- Added payment setup section in the settings page for pro
- Implemented conditional rendering based on user type
- Implemented Stripe connection button and status display
- Styled payment setup section 
- Adjusted the style of the personal info section 

## Functions supported
Pro can connect their Stripe accounts and see the connection status (FE only)

## To test
1. Log in as a pro
2. Navigate to Your Profile page
3. Verify personal information card is visible
4. Verify payment setup card is visible for pro only
5. Test UI states: (Manually update the database to mock the case for now)
   - Without stripeAccountId: Should show connect button
   - With stripeAccountId: Should show connected status

## References
- Without stripeAccountId:
<img width="657" alt="Screenshot_1" src="https://github.com/user-attachments/assets/808265ff-f607-4ef0-b2e5-35561ba74930" />

- With stripeAccountId:
<img width="681" alt="Screenshot_2" src="https://github.com/user-attachments/assets/53d58890-326d-4efd-94fe-a7309d016636" />
