### PR TITLE
Integrate Stripe Connect API and save the returned data to DB

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -24,6 +24,7 @@
         "qrcode": "^1.5.0",
         "reflect-metadata": "^0.2.1",
         "speakeasy": "^2.0.0",
+        "stripe": "^17.6.0",
         "ts-node": "^9.1.1"
       },
       "devDependencies": {
@@ -4973,6 +4974,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.6.0.tgz",
+      "integrity": "sha512-+HB6+SManp0gSRB0dlPmXO+io18krlAe0uimXhhIkL/RG/VIRigkfoM3QDJPkqbuSW0XsA6uzsivNCJU1ELEDA==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9228,6 +9241,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "stripe": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.6.0.tgz",
+      "integrity": "sha512-+HB6+SManp0gSRB0dlPmXO+io18krlAe0uimXhhIkL/RG/VIRigkfoM3QDJPkqbuSW0XsA6uzsivNCJU1ELEDA==",
+      "requires": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      }
     },
     "supports-color": {
       "version": "7.2.0",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -49,6 +49,7 @@
     "qrcode": "^1.5.0",
     "reflect-metadata": "^0.2.1",
     "speakeasy": "^2.0.0",
+    "stripe": "^17.6.0",
     "ts-node": "^9.1.1"
   }
 }

--- a/Backend/src/controllers/stripe/stripe.controller.ts
+++ b/Backend/src/controllers/stripe/stripe.controller.ts
@@ -1,0 +1,126 @@
+import { Router, Request, Response } from "express";
+import Stripe from "stripe";
+import Controller from "../../interfaces/controller.interface";
+import userModel from "../../models/user/user.model";
+
+/**
+ * Controller for handling Stripe Connect integration
+ * Manages professional service providers' payment accounts
+ */
+class StripeController implements Controller {
+    public path = "/stripe";
+    public router = Router();
+    private stripe: Stripe;
+    private user = userModel;
+
+    constructor() {
+        // Initialize Stripe with secret key and latest API version
+        this.stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+            apiVersion: "2025-01-27.acacia",
+        });
+        this.initializeRoutes();
+    }
+
+    /**
+     * Initialize all routes related to Stripe integration
+     */
+    private initializeRoutes() {
+        this.router.post(`${this.path}/connect-account`, this.createConnectAccount);
+        this.router.get(`${this.path}/account-status/:accountId`, this.getAccountStatus);
+        this.router.post(`${this.path}/update-stripe-id`, this.updateStripeAccountId);
+    }
+
+    /**
+     * Creates a Stripe Connect Express account for a service provider
+     * @param req Contains email and userId
+     * @param res Returns accountLink URL for onboarding and accountId
+     */
+    private createConnectAccount = async (req: Request, res: Response) => {
+        try {
+            const { email, userId } = req.body;
+
+            const account = await this.stripe.accounts.create({
+                type: "express",
+                email: email,
+                capabilities: {
+                    card_payments: { requested: true },
+                    transfers: { requested: true },
+                },
+            });
+           
+            // Generate onboarding link with success/failure redirects
+            const accountLink = await this.stripe.accountLinks.create({
+                account: account.id,
+                refresh_url: `${process.env.CLIENT_URL}/settings`,
+                return_url: `${process.env.CLIENT_URL}/stripe-onboarding-success?userId=${userId}&accountId=${account.id}`,
+                type: "account_onboarding",
+            });
+
+            res.json({
+                accountLink: accountLink.url,
+                accountId: account.id,
+            });
+        } catch (error: any) {
+            console.error("Stripe account creation error:", error);
+            res.status(500).json({ error: error.message });
+        }
+    };
+    /**
+     * Checks if a Stripe account has completed onboarding
+     * @param req Contains accountId in params
+     * @param res Returns completion status and accountId
+     */
+    private getAccountStatus = async (req: Request, res: Response) => {
+        try {
+            const { accountId } = req.params;
+            const account = await this.stripe.accounts.retrieve(accountId);
+
+            const isComplete = account.details_submitted && account.payouts_enabled;
+
+            res.json({
+                isComplete,
+                accountId: account.id,
+            });
+        } catch (error: any) {
+            console.error("Stripe account status check error:", error);
+            res.status(500).json({ error: error.message });
+        }
+    };
+    /**
+     * Updates user's Stripe account ID after successful onboarding
+     * @param req Contains userId and accountId
+     * @param res Returns updated user object
+     */
+    private updateStripeAccountId = async (req: Request, res: Response) => {
+        try {
+            const { userId, accountId } = req.body;
+
+            const account = await this.stripe.accounts.retrieve(accountId);
+            const isComplete = account.details_submitted && account.payouts_enabled;
+
+            if (!isComplete) {
+                return res.status(400).json({
+                    success: false,
+                    message: "Onboarding not completed yet.",
+                });
+            }
+
+            const updatedUser = await this.user.findByIdAndUpdate(
+                userId, 
+                { stripeAccountId: accountId }, 
+                { new: true }
+            );
+
+            if (!updatedUser) {
+                return res.status(404).json({ success: false, message: "User not found" });
+            }
+
+            res.json({ success: true, message: "Stripe account linked successfully.", user: updatedUser });
+        } catch (error: any) {
+            console.error("Error updating Stripe account ID:", error);
+            res.status(500).json({ error: error.message });
+        }
+    };
+}
+
+export default StripeController;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -8,6 +8,7 @@ import ContactController from "./controllers/contactus/contactus.controller";
 import SurveyController from "./controllers/survey/survey.controller";
 import validateEnv from "./utils/validateEnv";
 import TransactionController from "./controllers/transaction/transaction.controller";
+import StripeController from "./controllers/stripe/stripe.controller";
 
 validateEnv();
 
@@ -19,6 +20,7 @@ const app = new App([
     new CategoryController(),
     new SurveyController(),
     new TransactionController(),
+    new StripeController(),
 ]);
 
 app.listen();

--- a/ClientFront/src/app/app-routing.module.ts
+++ b/ClientFront/src/app/app-routing.module.ts
@@ -14,6 +14,8 @@ import { ResetPasswordComponent } from './modules/reset-password/reset-password.
 import { ProDetailsComponent } from './modules/pro-details/pro-details.component';
 import { ProProfileComponent } from './modules/pro-profile/pro-profile.component';
 import { AuthGuard } from './shared/guards/auth.guard';
+import { StripeSuccessComponent } from './modules/stripe-success/stripe-success.component';
+
 
 
 const routes: Routes = [
@@ -39,6 +41,7 @@ const routes: Routes = [
     { path: 'settings', component: SettingsComponent,   },
     { path: 'resetPassword/:id', component: ResetPasswordComponent },
     { path: 'proDetails', component: ProDetailsComponent },
+    { path: 'stripe-onboarding-success', component: StripeSuccessComponent },
 ];
 
 @NgModule({

--- a/ClientFront/src/app/app.module.ts
+++ b/ClientFront/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { ProjectReviewDialogComponent } from "./modules/project/project-review-d
 import { ResetPasswordComponent } from "./modules/reset-password/reset-password.component";
 import { ContactUsDialogComponent } from "./modules/contact-us/contact-us-dialog/contact-us-dialog/contact-us-dialog.component";
 import { ProProfileComponent } from "./modules/pro-profile/pro-profile.component";
+import { StripeSuccessComponent } from './modules/stripe-success/stripe-success.component';
 
 @NgModule({
   declarations: [
@@ -51,6 +52,7 @@ import { ProProfileComponent } from "./modules/pro-profile/pro-profile.component
     ResetPasswordComponent,
     ContactUsDialogComponent,
     ProProfileComponent,
+    StripeSuccessComponent,
   ],
   imports: [
     BrowserModule,

--- a/ClientFront/src/app/modules/settings/settings.component.ts
+++ b/ClientFront/src/app/modules/settings/settings.component.ts
@@ -5,7 +5,6 @@ import { User } from 'src/app/shared/models/user';
 import { HttpClient } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { environment } from 'src/environments/environment';
-import { UserService } from 'src/app/shared/services/user.service'; 
 
 @Component({
   selector: 'app-settings',
@@ -32,8 +31,7 @@ export class SettingsComponent implements OnInit {
     private authService: AuthService,
     private http: HttpClient,
     private route: ActivatedRoute,
-    private router: Router,
-    private userService: UserService
+    private router: Router
   ) { }
 
   ngOnInit(): void {
@@ -90,20 +88,23 @@ export class SettingsComponent implements OnInit {
    * @param accountId - Stripe Connect account ID
    */
   private updateStripeAccount(userId: string, accountId: string): void {
-    this.userService.setStripeAccountId(userId, accountId)
-        .subscribe({
-            next: (user) => {
-                console.log("Stripe account linked successfully");
-                this.successMessage = "Stripe account linked successfully!";
-                this.stripeAccountId = user.stripeAccountId || '';
-                this.stripeConnected = true;
-                this.router.navigate(['/settings']);
-            },
-            error: (err) => {
-                console.error("Error updating Stripe account:", err);
-                this.errorMessage = "Failed to update Stripe account. Please try again.";
-            }
-        });
+    this.http.patch(`${environment.apiEndpoint}/stripe-account/${userId}`, {
+      stripeAccountId: accountId
+    }).subscribe({
+      next: () => {
+        console.log("Stripe account linked successfully");
+        this.successMessage = "Stripe account linked successfully!";
+        this.stripeAccountId = accountId;
+        this.stripeConnected = true;
+
+        // clear query params from URL and navigate to settings
+        this.router.navigate(['/settings']);
+      },
+      error: (err) => {
+        console.error("Error updating Stripe account:", err);
+        this.errorMessage = "Failed to update Stripe account. Please try again.";
+      }
+    });
   }
 
   private populateForm(user: User): void {
@@ -155,7 +156,7 @@ export class SettingsComponent implements OnInit {
     }
     const userId = this.originalUserData._id;
     const email = this.originalUserData.email;
-    // Call backend to create Stripe Connect account
+
     this.http.post<{ accountLink: string }>(
       `${environment.apiEndpoint}/stripe/connect-account`,
       { email, userId }

--- a/ClientFront/src/app/modules/settings/settings.component.ts
+++ b/ClientFront/src/app/modules/settings/settings.component.ts
@@ -3,7 +3,9 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from 'src/app/shared/services/auth.service';
 import { User } from 'src/app/shared/models/user';
 import { HttpClient } from '@angular/common/http';
+import { ActivatedRoute, Router } from '@angular/router';
 import { environment } from 'src/environments/environment';
+import { UserService } from 'src/app/shared/services/user.service'; 
 
 @Component({
   selector: 'app-settings',
@@ -28,7 +30,10 @@ export class SettingsComponent implements OnInit {
     private fb: FormBuilder,
     private changeDetectorRef: ChangeDetectorRef,
     private authService: AuthService,
-    private http: HttpClient
+    private http: HttpClient,
+    private route: ActivatedRoute,
+    private router: Router,
+    private userService: UserService
   ) { }
 
   ngOnInit(): void {
@@ -46,6 +51,26 @@ export class SettingsComponent implements OnInit {
       postalCode: [{ value: '', disabled: true }],
     });
 
+    /**
+     * Listen for URL query parameters after Stripe onboarding redirect
+     * Checks for userId and accountId from Stripe callback
+     */
+    this.route.queryParams.subscribe(params => {
+      const userId = params['userId'];
+      const accountId = params['accountId'];
+
+      if (userId && accountId) {
+        this.updateStripeAccount(userId, accountId);
+      } else {
+        this.loadUserData();
+      }
+    });
+  }
+  /**
+   * Loads user data and sets up Stripe-related flags
+   * Called on component initialization and after profile updates
+   */
+  private loadUserData(): void {
     this.authService.user.subscribe((user) => {
       if (user) {
         this.originalUserData = user;
@@ -56,6 +81,29 @@ export class SettingsComponent implements OnInit {
         this.populateForm(user);
       }
     });
+  }
+
+  /**
+   * Updates user's Stripe account ID in database
+   * Called after successful Stripe onboarding
+   * @param userId - User's ID in our system
+   * @param accountId - Stripe Connect account ID
+   */
+  private updateStripeAccount(userId: string, accountId: string): void {
+    this.userService.setStripeAccountId(userId, accountId)
+        .subscribe({
+            next: (user) => {
+                console.log("Stripe account linked successfully");
+                this.successMessage = "Stripe account linked successfully!";
+                this.stripeAccountId = user.stripeAccountId || '';
+                this.stripeConnected = true;
+                this.router.navigate(['/settings']);
+            },
+            error: (err) => {
+                console.error("Error updating Stripe account:", err);
+                this.errorMessage = "Failed to update Stripe account. Please try again.";
+            }
+        });
   }
 
   private populateForm(user: User): void {
@@ -96,12 +144,32 @@ export class SettingsComponent implements OnInit {
     this.changeDetectorRef.detectChanges();
   }
 
+  /**
+   * Initiates Stripe Connect onboarding process
+   * Creates Stripe account and redirects to Stripe onboarding
+   */
   connectStripe(): void {
-    if(!this.originalUserData) {
+    if (!this.originalUserData) {
       this.errorMessage = 'Please sign in first';
       return;
     }
-    window.location.href = `${environment.apiEndpoint}/stripe/connect`
+    const userId = this.originalUserData._id;
+    const email = this.originalUserData.email;
+    // Call backend to create Stripe Connect account
+    this.http.post<{ accountLink: string }>(
+      `${environment.apiEndpoint}/stripe/connect-account`,
+      { email, userId }
+    ).subscribe({
+      next: (response) => {
+        console.log("Redirecting to Stripe Onboarding:", response.accountLink);
+        window.location.href = response.accountLink; 
+      },
+      error: (err) => {
+        console.error("Error creating Stripe account:", err);
+        this.errorMessage = "Failed to connect to Stripe. Please try again.";
+        setTimeout(() => { this.errorMessage = ''; }, 3000);
+      }
+    });
   }
 
   submitForm(): void {

--- a/ClientFront/src/app/modules/settings/settings.component.ts
+++ b/ClientFront/src/app/modules/settings/settings.component.ts
@@ -69,7 +69,7 @@ export class SettingsComponent implements OnInit {
    * Called on component initialization and after profile updates
    */
   private loadUserData(): void {
-    this.authService.checkSession().subscribe(user => {
+    this.authService.user.subscribe((user) => {
       if (user) {
         this.originalUserData = user;
         this.userId = user._id;

--- a/ClientFront/src/app/modules/settings/settings.component.ts
+++ b/ClientFront/src/app/modules/settings/settings.component.ts
@@ -69,7 +69,7 @@ export class SettingsComponent implements OnInit {
    * Called on component initialization and after profile updates
    */
   private loadUserData(): void {
-    this.authService.user.subscribe((user) => {
+    this.authService.checkSession().subscribe(user => {
       if (user) {
         this.originalUserData = user;
         this.userId = user._id;
@@ -77,6 +77,7 @@ export class SettingsComponent implements OnInit {
         this.stripeConnected = !!user.stripeAccountId;
         this.stripeAccountId = user.stripeAccountId || '';
         this.populateForm(user);
+        this.changeDetectorRef.detectChanges();  
       }
     });
   }

--- a/ClientFront/src/app/modules/stripe-success/stripe-success.component.html
+++ b/ClientFront/src/app/modules/stripe-success/stripe-success.component.html
@@ -1,0 +1,1 @@
+<p>stripe-success works!</p>

--- a/ClientFront/src/app/modules/stripe-success/stripe-success.component.spec.ts
+++ b/ClientFront/src/app/modules/stripe-success/stripe-success.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StripeSuccessComponent } from './stripe-success.component';
+
+describe('StripeSuccessComponent', () => {
+  let component: StripeSuccessComponent;
+  let fixture: ComponentFixture<StripeSuccessComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StripeSuccessComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StripeSuccessComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ClientFront/src/app/modules/stripe-success/stripe-success.component.ts
+++ b/ClientFront/src/app/modules/stripe-success/stripe-success.component.ts
@@ -23,7 +23,7 @@ export class StripeSuccessComponent implements OnInit {
         this.userService.setStripeAccountId(userId, accountId).subscribe({
           next: () => {
             console.log('Stripe account linked successfully');
-            this.router.navigate(['/settings']); 
+            window.location.href = '/settings';
           },
           error: (error) => {
             console.error('Error updating Stripe account:', error);

--- a/ClientFront/src/app/modules/stripe-success/stripe-success.component.ts
+++ b/ClientFront/src/app/modules/stripe-success/stripe-success.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { UserService } from 'src/app/shared/services/user.service';
+
+@Component({
+  selector: 'app-stripe-success',
+  template: '', 
+  styleUrls: []
+})
+export class StripeSuccessComponent implements OnInit {
+  constructor(
+    private route: ActivatedRoute,
+    private userService: UserService,
+    private router: Router
+  ) {}
+
+  ngOnInit() {
+    this.route.queryParams.subscribe(params => {
+      const userId = params['userId'];
+      const accountId = params['accountId'];
+
+      if (userId && accountId) {
+        this.userService.setStripeAccountId(userId, accountId).subscribe({
+          next: () => {
+            console.log('Stripe account linked successfully');
+            this.router.navigate(['/settings']); 
+          },
+          error: (error) => {
+            console.error('Error updating Stripe account:', error);
+            this.router.navigate(['/settings']); 
+          }
+        });
+      } else {
+        this.router.navigate(['/settings']);
+      }
+    });
+  }
+}


### PR DESCRIPTION
### **This PR implements:**

1. Stripe Onboarding Integration to streamline pro's stripe onboarding process
2. Update of their Stripe account ID in our database.  

### **Changes Implemented:**
**Create Connect Account**
- Create Stripe Express account
- Generate onboarding link for account setup
- Return link for frontend redirect, if pros setup their account in onboarding stripe page

**Check Account Status**
- Verify if account has completed onboarding
- Return completion status to frontend

**Update Stripe ID**
- Verify onboarding completion
- Save Stripe account ID to in DB


### **How to Test**

1. In Pro Setting page, please clicks “Connect with Stripe” button.
2. The frontend requests an onboarding link from the backend and redirects the user to Stripe Onboarding Page.
3. After onboarding, Stripe redirects the user back to our platform (setting page).
4. The system validates onboarding completion, updates the database
5. The settings page will show the Stripe ID and connectnion status.
<img width="820" alt="image" src="https://github.com/user-attachments/assets/bf243083-7f57-4842-ac6d-544495557a49" />

### **Preparation**

1. In Backend directory, please install the stripe by using `npm install stripe`
2. In Backend directory update the .env file shared in discord
