### PR TITLE
add confirm & reject btns

### DIFF
--- a/Backend/src/controllers/project/project.controller.ts
+++ b/Backend/src/controllers/project/project.controller.ts
@@ -317,7 +317,8 @@ class ProjectController implements Controller {
                     serviceId: projectData.serviceId,
                     client: user,
                     professional: professional,
-                    rating: 0
+                    rating: 0,
+                    priceConfirmed: false,
                 });
                 const savedProject = await createdproject.save();
                 await savedProject.populate('professional', '-password').execPopulate();

--- a/ClientFront/src/app/modules/project/project.component.html
+++ b/ClientFront/src/app/modules/project/project.component.html
@@ -16,10 +16,6 @@
             {{ "Label.UpdatedDate" | translate }}:
             {{ project.updatedAt | date }}
           </h3>
-          <!-- <h3 class="h3Details">
-                        {{ 'Label.BillingCost' | translate }}:
-                         {{ projectPrice }}
-                    </h3> -->
           <h3 class="h3Details" *ngIf="project.state === 'OnGoing'">
             {{ "Estimated Price" | translate }}:
             {{ projectPrice }}
@@ -27,6 +23,17 @@
           <h3 class="h3Details" *ngIf="project.state === 'Completed'">
             {{ "Label.BillingCost" | translate }}:
             {{ projectPrice }}
+            <span *ngIf="!project.priceConfirmed && project.clientResponse === null">
+              <button mat-raised-button color="primary" class="confirm-btn" (click)="confirmPrice()">
+                {{ "Confirm" | translate }}
+              </button>
+              <button mat-raised-button color="warn" class="reject-btn" (click)="rejectPrice()">
+                {{ "Reject" | translate }}
+              </button>
+            </span>
+            <span *ngIf="project.clientResponse" [ngClass]="{ 'text-success': project.clientResponse === 'confirmed', 'text-danger': project.clientResponse === 'rejected' }">
+              ({{ project.clientResponse | titlecase | translate }})
+            </span>
           </h3>
         <h3 class="h3Details">
           {{ "Payment Status" | translate }}:

--- a/ClientFront/src/app/modules/project/project.component.html
+++ b/ClientFront/src/app/modules/project/project.component.html
@@ -23,7 +23,7 @@
           <h3 class="h3Details" *ngIf="project.state === 'Completed'">
             {{ "Label.BillingCost" | translate }}:
             {{ projectPrice }}
-            <span *ngIf="!project.priceConfirmed && project.clientResponse === null">
+            <span *ngIf="isCustomer && !project.priceConfirmed && project.clientResponse === null">
               <button mat-raised-button color="primary" class="confirm-btn" (click)="confirmPrice()">
                 {{ "Confirm" | translate }}
               </button>

--- a/ClientFront/src/app/modules/project/project.component.scss
+++ b/ClientFront/src/app/modules/project/project.component.scss
@@ -404,3 +404,23 @@ h3.skills {
 .status-failed {
   color: #f44336; 
 }
+
+.confirm-btn, .reject-btn {
+  align-items: center !important;
+  justify-content: center !important;
+  text-align: center !important;
+  border-radius: 45px !important;
+  color: white !important;
+  transition: background-color 0.3s ease, transform 0.3s ease;
+  size: 3vh;
+}
+
+.confirm-btn {
+  background-color:#4caf50;
+}
+
+.reject-btn {
+  background-color:#f44336;
+}
+
+

--- a/ClientFront/src/app/modules/project/project.component.ts
+++ b/ClientFront/src/app/modules/project/project.component.ts
@@ -301,4 +301,23 @@ export class ProjectComponent implements OnInit, AfterViewChecked, OnDestroy {
       data: { projectID: this.projectId },
     });
   }
+
+
+  public confirmPrice(): void {
+    if (this.project) {
+      this.projectService.updateClientResponse(this.project._id, 'confirmed').pipe(first()).subscribe((updatedProject) => {
+        this.project = updatedProject;
+        this.changeDetectorRef.markForCheck();
+      });
+    }
+  }
+
+  public rejectPrice(): void {
+    if (this.project) {
+      this.projectService.updateClientResponse(this.project._id, 'rejected').pipe(first()).subscribe((updatedProject) => {
+        this.project = updatedProject;
+        this.changeDetectorRef.markForCheck();
+      });
+    }
+  }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/cRfuywDU

> When conditions (project state = Complete, priceConfirmed = false, clientResponse = null) are met, Confirm and Reject buttons appear next to the price.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/4b36deba-9322-472c-99be-226f44467aa5" />

> Clicking Confirm updates priceConfirmed to true and clientResponse to "confirmed", updating the UI.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f651ccba-3800-48df-9f0b-b6be2d0e21a1" />

> Clicking Reject updates clientResponse to "rejected", updating the UI.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bd65c986-7dbb-4c0d-a1d8-9fee88430655" />

