### PR TITLE
Payment Status & Payment Buttons

### DIFF
--- a/ClientFront/src/app/modules/project/project.component.html
+++ b/ClientFront/src/app/modules/project/project.component.html
@@ -23,19 +23,19 @@
           <h3 class="h3Details" *ngIf="project.state === 'Completed'">
             {{ "Label.BillingCost" | translate }}:
             {{ projectPrice }}
-            <span *ngIf="isCustomer && !project.priceConfirmed && project.clientResponse === null">
+            <div *ngIf="isCustomer && !project.priceConfirmed && project.clientResponse === null" class = "price-confirm">
               <button mat-raised-button color="primary" class="confirm-btn" (click)="confirmPrice()">
                 {{ "Confirm" | translate }}
               </button>
               <button mat-raised-button color="warn" class="reject-btn" (click)="rejectPrice()">
                 {{ "Reject" | translate }}
               </button>
-            </span>
+            </div>
             <span *ngIf="project.clientResponse" [ngClass]="{ 'text-success': project.clientResponse === 'confirmed', 'text-danger': project.clientResponse === 'rejected' }">
               ({{ project.clientResponse | titlecase | translate }})
             </span>
           </h3>
-        <h3 class="h3Details" *ngIf="project?.state === 'Completed'|| project?.state === 'Paid'">
+        <h3 class="h3Details" *ngIf="project.priceConfirmed">
           {{ "Payment Status" | translate }}:
           <span [ngClass]="getPaymentStatusClass(transaction?.status)">
             {{ getPaymentStatusDisplay() | translate }}

--- a/ClientFront/src/app/modules/project/project.component.html
+++ b/ClientFront/src/app/modules/project/project.component.html
@@ -35,7 +35,7 @@
               ({{ project.clientResponse | titlecase | translate }})
             </span>
           </h3>
-        <h3 class="h3Details">
+        <h3 class="h3Details" *ngIf="project?.state === 'Completed'|| project?.state === 'Paid'">
           {{ "Payment Status" | translate }}:
           <span [ngClass]="getPaymentStatusClass(transaction?.status)">
             {{ getPaymentStatusDisplay() | translate }}

--- a/ClientFront/src/app/modules/project/project.component.html
+++ b/ClientFront/src/app/modules/project/project.component.html
@@ -41,6 +41,15 @@
             {{ getPaymentStatusDisplay() | translate }}
           </span>
         </h3>
+        <button
+          class="completeJob"
+          mat-raised-button
+          *ngIf="isCustomer && project.state === 'Completed' && project.priceConfirmed"
+          (click)="onPayProject()"
+        >
+          <strong>{{ 'Make Payment' | translate }}</strong>
+        </button>
+      
           <br />
 
           <h2 class="h3Details">

--- a/ClientFront/src/app/modules/project/project.component.scss
+++ b/ClientFront/src/app/modules/project/project.component.scss
@@ -191,7 +191,7 @@ h1 {
 
 ::ng-deep .mat-tab-group.mat-primary .mat-tab-labels .mat-tab-label:focus,
 ::ng-deep .mat-tab-group.mat-primary .mat-tab-labels .mat-tab-label.mat-ripple {
-  background-color: rgba(0, 2, 5, 0.1);
+  background-color: rgba(79, 85, 96, 0.1);
 }
 
 .responsive-heading {
@@ -422,5 +422,4 @@ h3.skills {
 .reject-btn {
   background-color:#f44336;
 }
-
 

--- a/ClientFront/src/app/modules/project/project.component.scss
+++ b/ClientFront/src/app/modules/project/project.component.scss
@@ -423,3 +423,7 @@ h3.skills {
   background-color:#f44336;
 }
 
+.price-confirm{
+  margin-top:-15px;
+}
+

--- a/ClientFront/src/app/modules/project/project.component.ts
+++ b/ClientFront/src/app/modules/project/project.component.ts
@@ -320,4 +320,28 @@ export class ProjectComponent implements OnInit, AfterViewChecked, OnDestroy {
       });
     }
   }
+
+  public onPayProject(): void {
+    if (!this.project) {
+      console.error('Project not found');
+      return;
+    }
+    
+    if (!this.user?._id) {
+      console.error('User not authenticated');
+      return;
+    }
+  
+    this.projectService.payProject(this.project._id, this.user._id)
+      .pipe(first())
+      .subscribe({
+        next: (updatedProject) => {
+          this.project = updatedProject;
+          this.changeDetectorRef.markForCheck();
+        },
+        error: (error) => {
+          console.error('Payment failed:', error);
+        }
+      });
+  }
 }

--- a/ClientFront/src/app/modules/projects-list/projects-list.component.html
+++ b/ClientFront/src/app/modules/projects-list/projects-list.component.html
@@ -30,7 +30,7 @@
                                 </td>
                             </ng-container>
 
-                            <ng-container matColumnDef="viewProject">
+                            <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let element">
                                     <button *ngIf="element.state && element.serviceName !== 'No project to show'"
@@ -99,7 +99,7 @@
                                 </td>
                             </ng-container>
 
-                            <ng-container matColumnDef="viewProject">
+                            <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let element">
                                     <button *ngIf="element.state && element.serviceName !== 'No project to show'"
@@ -163,14 +163,20 @@
                                 </td>
                             </ng-container>
 
-                            <ng-container matColumnDef="viewProject">
+                            <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let element">
                                     <button *ngIf="element.state && element.serviceName !== 'No project to show'"
                                         mat-raised-button class="btnProfiles" (click)="goToProject(element._id)">
                                         {{ 'Dictionary.ViewProject' | translate }}
                                     </button>
-
+                                    <button 
+                                    *ngIf="isCustomer && element.state === 'Completed' && element.priceConfirmed"
+                                    mat-raised-button 
+                                    class="btnPayment"
+                                    (click)="onPayProject(element._id, user?._id)">
+                                    {{ 'Make Payment' | translate }}
+                                  </button>
                                 </td>
                             </ng-container>
 
@@ -219,7 +225,7 @@
                                 </td>
                             </ng-container>
 
-                            <ng-container matColumnDef="viewProject">
+                            <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let element">
                                     <button *ngIf="element.state && element.serviceName !== 'No project to show'"
@@ -286,7 +292,7 @@
                                 </td>
                             </ng-container>
 
-                            <ng-container matColumnDef="viewProject">
+                            <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let element">
                                     <button *ngIf="element.state && element.serviceName !== 'No project to show'"
@@ -350,7 +356,7 @@
                                 </td>
                             </ng-container>
 
-                            <ng-container matColumnDef="viewProject">
+                            <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let element">
                                     <button *ngIf="element.state && element.serviceName !== 'No project to show'"

--- a/ClientFront/src/app/modules/projects-list/projects-list.component.scss
+++ b/ClientFront/src/app/modules/projects-list/projects-list.component.scss
@@ -206,8 +206,15 @@ input.mat-input-element {
   white-space: nowrap; 
 }
 
-.btnProfiles, .mat-form-field, input.mat-input-element {
 
+.btnPayment{
+  @extend .btnProfiles;
+  background-color: white;
+  color:#225d9c;
+}
+
+.btnPayment:hover, .btnPayment:focus {
+  background-color: #c3ccd6;
 }
 
 
@@ -224,8 +231,7 @@ input.mat-input-element {
       padding: 1rem; 
       margin: 10px auto; 
   }
+
 }
-
-
 
 

--- a/ClientFront/src/app/modules/projects-list/projects-list.component.ts
+++ b/ClientFront/src/app/modules/projects-list/projects-list.component.ts
@@ -32,12 +32,12 @@ export class ProjectsListComponent implements OnInit {
         'status',
         'dateCreated',
         'dateCompleted',
-        'viewProject',
+        'actions'    
     ];
     displayedColumnsRequest: string[] = [
         'serviceName',
         'dateCreated',
-        'viewProject',
+        'actions'
     ];
 
     public dataSource: MatTableDataSource<Project>;
@@ -63,9 +63,7 @@ export class ProjectsListComponent implements OnInit {
         this.authService.checkSession().subscribe({
             next: (user) => {
                 
-
                 this.user = user;
-                
                 this.authService.setUserValue(user);
                 this.subscribeToUserChanges();
                 this.changeDetectorRef.detectChanges();
@@ -228,5 +226,20 @@ export class ProjectsListComponent implements OnInit {
 
     public toggleView(): void {
         this.isCustomer = !this.isCustomer;
+    }
+
+    public onPayProject(projectId:string, clientId:string|undefined): void {
+        if (!clientId) {
+            console.error('Client ID is missing');
+            return;
+        }
+        this.projectService.payProject(projectId, clientId).subscribe({
+            next: (project) => {
+                this.fetchProjects(this.user);
+            },
+            error: (error) => {
+                console.error('Error paying project', error);
+            }
+        });
     }
 }


### PR DESCRIPTION
1. Hide "Payment Status" before price is confirmed: now it only shows after client clicked "Confirm", which makes more sense.

2. Adjusted "confirm/reject" button a little bit to make it align better 
<img width="520" alt="image" src="https://github.com/user-attachments/assets/6752f182-a157-4cd1-804e-93ee0d3c1d6a" />

3. Added "Make Payment" button to both project list and detail pages when price is confirmed:

<img width="997" alt="image" src="https://github.com/user-attachments/assets/57904919-807b-4793-9062-8dc95f0f533b" />

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/0e146d15-0d72-41d2-922f-998c84c002e1" />

The buttons now triggers a dummy backend API written by the previous team.

The API functions is in `project.controller.ts`, a function called `private payProject`, where @nzzzzzw could modify the logic to redirect the user to the actual payment page.


