### PR TITLE
Standardize menu items' layout in navigation dropdown in Client Front End

### DIFF
--- a/ClientFront/src/app/app.component.scss
+++ b/ClientFront/src/app/app.component.scss
@@ -140,6 +140,15 @@ footer {
     min-width: 70px;
   }
 
+  .mat-menu-item {
+    font-size: 14px;
+    line-height: 18px;
+  }
+  .mat-menu-item label {
+    font-size: 14px;
+    margin: 0;
+  }
+
   #dropdownButton {
     margin: 0 0.25rem;
   }


### PR DESCRIPTION
**Description**
This PR standardizes buttons in the user dropdown menu to ensure a consistent appearance across all menu items. It addresses an issue where menu text had inconsistent sizing or positions.

**Screenshots:**
Before:
<img width="136" alt="image" src="https://github.com/user-attachments/assets/2c7be3cd-ce84-45be-b16a-8221b8b54ffc" />
After:
<img width="147" alt="image" src="https://github.com/user-attachments/assets/b738d00d-3df7-44f4-a6f8-dd20a974b0ca" />

